### PR TITLE
pgvector: distribute connections across comma-separated host list

### DIFF
--- a/vectordb_bench/backend/clients/pgvector/pgvector.py
+++ b/vectordb_bench/backend/clients/pgvector/pgvector.py
@@ -1,6 +1,7 @@
 """Wrapper around the Pgvector vector database over VectorDB"""
 
 import logging
+import random
 from collections.abc import Generator, Sequence
 from contextlib import contextmanager
 from typing import Any
@@ -89,6 +90,19 @@ class PgVector(VectorDB):
 
     @staticmethod
     def _create_connection(**kwargs) -> tuple[Connection, Cursor]:
+        # `host` may be a comma-separated list of YugabyteDB nodes. perfservice passes
+        # the full tserver-nodes list (instead of the single master-leader) when load
+        # balancing is requested. Each concurrent-search worker is its own process
+        # opening one long-lived connection, so picking a node at random here spreads
+        # connections ~evenly across the cluster -- avoiding the one-hot-node we get
+        # when every worker connects to the same host. A single host (no comma) is a
+        # no-op, so default runs are unchanged.
+        host = kwargs.get("host")
+        if host and "," in host:
+            candidates = [h.strip() for h in host.split(",") if h.strip()]
+            if candidates:
+                kwargs["host"] = random.choice(candidates)
+
         conn = psycopg.connect(**kwargs)
         register_vector(conn)
         conn.autocommit = False


### PR DESCRIPTION
`host` may now be a comma-separated list of YugabyteDB nodes (perfservice passes the full tserver-nodes list when load balancing is requested). Each concurrent search worker is its own process opening one connection, so split the list and random.choice a node per worker -- connections fan out across the cluster instead of all hitting one node. A single host (no comma) is a no-op, so default runs are unchanged.

Random (not least-connections): N independent worker processes have no shared counter, so querying per-node load would herd them onto the same node; random avoids that and is a strict improvement over one hot node.

Pipeline plumbing (load_balance flag, json_to_yaml host selection) lives in the perf-devops repo on branch vdbbench-lb-tserver-nodes.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

---
_automated · Claude Code (Opus 4.8 1M)_